### PR TITLE
Add support for CRI log format in fluentd

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gem "fluentd", "1.7.4"
 gem "fluent-plugin-kubernetes_metadata_filter", "~> 2.3.0"
 gem "fluent-plugin-syslog_rfc5424", "0.7.3"
+gem 'fluent-plugin-multi-format-parser', '1.0.0'

--- a/config/manifests/300-fluentd-config.yaml
+++ b/config/manifests/300-fluentd-config.yaml
@@ -8,6 +8,10 @@ metadata:
 data:
   fluentd.conf: |
     # Inputs
+    <match kubernetes.var.log.containers.fluentd**>
+      @type null
+    </match>
+
     <source>
       @type tail
       @id in_tail_container_logs
@@ -15,8 +19,16 @@ data:
       pos_file /var/log/fluentd-containers.log.pos
       tag kubernetes.*
       <parse>
-        @type json
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
+        @type multi_format
+        <pattern>
+          format json
+          time_key time
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
+          time_format %Y-%m-%dT%H:%M:%S.%N%:z
+        </pattern>
       </parse>
       read_from_head true
     </source>


### PR DESCRIPTION
In addition to that, ignore fluentd's own logs to avoid infinite loops
of logs.

fixes #3