### PR TITLE
Let bump-cf-for-k8s run without coreutils

### DIFF
--- a/scripts/bump-cf-for-k8s.sh
+++ b/scripts/bump-cf-for-k8s.sh
@@ -3,7 +3,7 @@
 set -ex
 
 CF_FOR_K8s_DIR="${CF_FOR_K8s_DIR:-${HOME}/workspace/cf-for-k8s/}"
-SCRIPT_DIR="$(dirname $(realpath $0))"
+SCRIPT_DIR="$(cd $(dirname $0) && pwd -P)"
 BASE_DIR="${SCRIPT_DIR}/.."
 
 pushd "${CF_FOR_K8s_DIR}"


### PR DESCRIPTION
This allows usage of the script on a stock Mac OS X installation.