### PR TITLE
Remove `imagePullSecrets` from PodSpec

### DIFF
--- a/config/manifests/500-fluentd-daemonset.yaml
+++ b/config/manifests/500-fluentd-daemonset.yaml
@@ -20,8 +20,6 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
-      imagePullSecrets:
-      - name: image-registry-credentials
       containers:
       - name: fluentd
         image: #@ data.values.images.fluent


### PR DESCRIPTION
The specificity makes it difficult to inject pull secrets via other means, such as Service Accounts.