### PR TITLE
Fluentd prometheus

### DIFF
--- a/config/300-fluentd-config.yaml
+++ b/config/300-fluentd-config.yaml
@@ -47,6 +47,7 @@ metadata:
   namespace: #@ data.values.system_namespace
 data:
   aggregate_drains.conf: #@ aggregate_drain_config
+  #@yaml/text-templated-strings
   fluentd.conf: |
     # Inputs
     <source>
@@ -76,6 +77,22 @@ data:
           time_format %Y-%m-%dT%H:%M:%S.%N%:z
         </pattern>
       </parse>
+    </source>
+
+    # expose metrics in prometheus format
+    <source>
+      @type prometheus
+      bind 0.0.0.0
+      port (@= data.values.fluentd.prometheus.port @)
+      metrics_path (@= data.values.fluentd.prometheus.path @)
+    </source>
+
+    <source>
+      @type prometheus_output_monitor
+      interval 10
+      <labels>
+        hostname ${hostname}
+      </labels>
     </source>
 
     <filter kubernetes.**>

--- a/config/500-fluentd-daemonset.yaml
+++ b/config/500-fluentd-daemonset.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       labels:
         app: fluentd
+    annotations:
+      prometheus.io/scrape: 'true'
+      prometheus.io/path: #@ data.values.fluentd.prometheus.path
+      prometheus.io/port: #@ data.values.fluentd.prometheus.port
     spec:
       serviceAccountName: fluentd-service-account
       tolerations:

--- a/config/500-fluentd-daemonset.yaml
+++ b/config/500-fluentd-daemonset.yaml
@@ -15,10 +15,10 @@ spec:
     metadata:
       labels:
         app: fluentd
-    annotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/path: #@ data.values.fluentd.prometheus.path
-      prometheus.io/port: #@ data.values.fluentd.prometheus.port
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/path: #@ data.values.fluentd.prometheus.path
+        prometheus.io/port: #@ data.values.fluentd.prometheus.port
     spec:
       serviceAccountName: fluentd-service-account
       tolerations:

--- a/config/values.yml
+++ b/config/values.yml
@@ -4,6 +4,11 @@ system_domain: ""
 system_namespace: ""
 app_log_destinations: []
 
+fluentd:
+  prometheus:
+    path: '/metrics'
+    port: '24231'
+
 images:
   log_cache: ""
   syslog_server: ""

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -6,8 +6,8 @@ directories:
       sha: 359b4774261a929c7911e5619ac41e90c71c5bcd
     path: log-cache
   - git:
-      commitTitle: upgrade fluentd...
-      sha: b65f09c4a4d0098b95ee7815384445c6ffbd54d3
+      commitTitle: prometheus plugin
+      sha: 57d4c407d1f6d474b56860c4b2de87ea067a586e
     path: cf-k8s-logging-fluent
   path: vendor
 kind: LockConfig

--- a/vendir.lock.yml
+++ b/vendir.lock.yml
@@ -7,7 +7,7 @@ directories:
     path: log-cache
   - git:
       commitTitle: prometheus plugin
-      sha: 57d4c407d1f6d474b56860c4b2de87ea067a586e
+      sha: 86fb30eb99baeb7b23e8900d364c08ef93cd9ebc
     path: cf-k8s-logging-fluent
   path: vendor
 kind: LockConfig

--- a/vendir.yml
+++ b/vendir.yml
@@ -10,4 +10,4 @@ directories:
   - path: cf-k8s-logging-fluent
     git:
       url: https://github.com/cloudfoundry/cf-k8s-logging-fluent
-      ref: b65f09c4a4d0098b95ee7815384445c6ffbd54d3
+      ref: 57d4c407d1f6d474b56860c4b2de87ea067a586e

--- a/vendir.yml
+++ b/vendir.yml
@@ -10,4 +10,4 @@ directories:
   - path: cf-k8s-logging-fluent
     git:
       url: https://github.com/cloudfoundry/cf-k8s-logging-fluent
-      ref: 57d4c407d1f6d474b56860c4b2de87ea067a586e
+      ref: 86fb30eb99baeb7b23e8900d364c08ef93cd9ebc

--- a/vendor/cf-k8s-logging-fluent/fluentd/Gemfile
+++ b/vendor/cf-k8s-logging-fluent/fluentd/Gemfile
@@ -4,3 +4,4 @@ gem "fluentd", "1.11.2"
 gem "fluent-plugin-kubernetes_metadata_filter", "~> 2.5.2"
 gem "fluent-plugin-syslog_rfc5424", "0.8.0"
 gem 'fluent-plugin-multi-format-parser', '1.0.0'
+gem "fluent-plugin-prometheus", "~>1.6.1"

--- a/vendor/cf-k8s-logging-fluent/fluentd/Gemfile
+++ b/vendor/cf-k8s-logging-fluent/fluentd/Gemfile
@@ -4,4 +4,4 @@ gem "fluentd", "1.11.2"
 gem "fluent-plugin-kubernetes_metadata_filter", "~> 2.5.2"
 gem "fluent-plugin-syslog_rfc5424", "0.8.0"
 gem 'fluent-plugin-multi-format-parser', '1.0.0'
-gem "fluent-plugin-prometheus", "~>1.6.1"
+gem "fluent-plugin-prometheus", "~>1.8.3"


### PR DESCRIPTION
Allows prometheus to scrape fluentd metrics
* Note: this is blocked on the merge of [this PR](https://github.com/cloudfoundry/cf-k8s-logging-fluent/pull/5)

[#173778282]