### PR TITLE
Increase progressDeadlineSeconds for log-cache deployment

### DIFF
--- a/config/log-cache-api-deployment.yaml
+++ b/config/log-cache-api-deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app: log-cache-api
 spec:
+  progressDeadlineSeconds: 1200
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
On some IaaSes, we've found that UAA takes longer than 10 minutes to start. This leads the `kapp deploy` to fail for log-cache once the deployment has been struggling for 10 minutes.

Note that the default value is 600 seconds.